### PR TITLE
fix(noren-plugin-network): remove peerDependencies and add @types/node

### DIFF
--- a/packages/noren-plugin-network/package.json
+++ b/packages/noren-plugin-network/package.json
@@ -45,10 +45,8 @@
   "dependencies": {
     "@himorishige/noren-core": "workspace:*"
   },
-  "peerDependencies": {
-    "@himorishige/noren-core": "^0.6.0"
-  },
   "devDependencies": {
+    "@types/node": "^20",
     "typescript": "^5.6.3",
     "vitest": "^3.2.4"
   },


### PR DESCRIPTION
- Remove unnecessary peerDependencies configuration that was causing CI TypeScript resolution issues
- Add missing @types/node devDependency for consistency with other plugins
- This should resolve the persistent 'Cannot find module @himorishige/noren-core' error in CI

🤖 Generated with [Claude Code](https://claude.ai/code)